### PR TITLE
Add support for `webpack --optimize-minimize` and use relative filepaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ejs-compiled-loader for webpack
 
-EJS loader for [webpack](http://webpack.github.io/). Uses [ejs](https://github.com/tj/ejs) function to compile templates.
+EJS loader for [webpack](http://webpack.github.io/). Uses [ejs](https://github.com/mde/ejs) function to compile templates.
 
-To use EJS by tj use 1.x branch and 1.x.x versions.
+To use [EJS by tj](https://github.com/tj/ejs) use 1.x branch and 1.x.x versions.
 
 ## Installation
 


### PR DESCRIPTION
Hi,

right now the ejs-compiled-loader adds full filepathes e.g. `'/Users/jantimon/Desktop/ejs-compiled-loader/test/template.ejs'` which is probably not a good idea.

This pullrequest changes this to `template.ejs` (relative to the webpack context).

This pullrequest adds also support for `webpack --optimize-minimize` and fixes a link in the readme.

What do you think?
