### PR TITLE
Fix typo in documentation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ template(data) // Pass object with data
 
 Following options can be specified in query:
 
-`beatify` — enable or disable uglify-js beautify of teamplate ast
+`beautify` — enable or disable uglify-js beautify of template ast
 
 `compileDebug` — see ejs compileDebug option
 


### PR DESCRIPTION
There was a minor typo in the documentation. "beautify" and "template" was misspelt. This fixes that,
