### PR TITLE
Use loader options if available for webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ var ejs = require('ejs'),
 
 module.exports = function (source) {
   this.cacheable && this.cacheable();
-  var opts = merge(this.options['ejs-compiled-loader'] || {}, utils.parseQuery(this.query));
+
+  var query = typeof this.query === 'object' ? this.query : utils.parseQuery(this.query);
+  var opts = merge(this.options['ejs-compiled-loader'] || {}, query);
   opts.client = true;
 
   // Skip compile debug for production when running with


### PR DESCRIPTION
In webpack 2 and above there is a validation of the configuration schema. Therefore, any loader configurations should be in the [loader's `options` object](https://webpack.js.org/configuration/module/#useentry).

So instead of configuring everything in the root of the config:

```javascript
module.exports = {
  // ...
  'ejs-compiled-loader': {
    'htmlmin': true, // or enable here  
    'htmlminOptions': {
      removeComments: true
    }
  }
  // ...
};
```

You would set everything in the loader's options:

```javascript
module.exports = {
  // ...
  module: {
    rules: [{
      test: /\.(ejs)$/,
      use: {
        loader: 'ejs-compiled-loader',
        options: {
          htmlmin: true,
        },
      },
    }]
  }
};
```

This PR shouldn't break on previous versions of webpack.