### PR TITLE
fix: add child to webpack deps #31,#19

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ module.exports = function (source) {
 
   var template = ejs.compile(source, opts);
 
+  if (template.dependencies.length > 0) {
+    template.dependencies.map(dep => this.addDependency(dep));
+  }
+
   // Beautify javascript code
   if (!this.minimize && opts.beautify !== false) {
     var ast = UglifyJS.parse(template.toString());


### PR DESCRIPTION
1. `ejs.compile()` will return dependencies of the current building template.
2. `addDependcy` will add them to webpack's dependency tree, so watching will work.