### PR TITLE
webpack 4 fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (source) {
   this.cacheable && this.cacheable();
 
   var query = typeof this.query === 'object' ? this.query : utils.parseQuery(this.query);
-  var opts = merge(this.options['ejs-compiled-loader'] || {}, query);
+  var opts = merge(this.options && this.options['ejs-compiled-loader'] || {}, query);
   opts.client = true;
 
   // Skip compile debug for production when running with


### PR DESCRIPTION
Webpack 4 does no longer support `this.options`. The current implementation throws an error in Webpack 4.

https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202