### PR TITLE
Use utils.getOptions() to get loader options

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,7 @@ module.exports = function (source) {
   this.cacheable && this.cacheable();
 
   // wepkack3: options
-  var options = (this.hasOwnProperty("options") && (typeof this.options['ejs-compiled-loader'] === 'object')) ? this.options['ejs-compiled-loader'] : {};
-  
-  // webpack4: query 
-  var query = (this.hasOwnProperty("query")) ? (typeof this.query === 'object') ? this.query : utils.parseQuery(this.query) : {};
+  var options = utils.getOptions(this);
   
   // merge opts from defaults,opts and query 
   var opts = merge({
@@ -22,7 +19,7 @@ module.exports = function (source) {
     beautify: false,
     htmlmin: (typeof this.htmlmin === 'boolean') ? this.htmlmin : false,
     htmlminOptions: {}
-  }, options, query);
+  }, options);
 
   // minify html
   if (opts.htmlmin) source = htmlmin.minify(source, opts.htmlminOptions);


### PR DESCRIPTION
Drop manually reading/parsing the options passed through Loader API in favor for the getOptions method already provided by loader-utils, soon to be integrated into webpack5 itself.

Tested and working with both inline query and options object, using only minimal htmlminify options as shown here: https://github.com/bazilio91/ejs-compiled-loader#htmlminify

Note: I did not test any other options. Potential problems if "merge" does not create a "deep copy" of options since it's returned read-only by getOptions()!