### PR TITLE
fix: recompile parent template automatically when child template is changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = function (source) {
 
   // wepkack3: options
   var options = utils.getOptions(this);
-  
-  // merge opts from defaults,opts and query 
+
+  // merge opts from defaults,opts and query
   var opts = merge({
     client: true,
     compileDebug: !!this.minimize,
@@ -23,6 +23,18 @@ module.exports = function (source) {
 
   // minify html
   if (opts.htmlmin) source = htmlmin.minify(source, opts.htmlminOptions);
+
+  // Build open delimiter from options
+  const delim = opts.delimiter || "%";
+  const open = opts.openDelimiter || "<";
+  let openDelimiter = "<%".replace(/%/g, delim).replace(/</g, open)
+
+  // Find included files and add them to webpack dependencies
+  let regexp = new RegExp(`${openDelimiter}-\\sinclude\\s+(\\S+)`, "gi");
+  const array = [...source.matchAll(regexp)];
+  array.forEach(([match, link]) => {
+    this.addDependency(path.resolve(this.context, link))
+  });
 
   // compile template
   var template = ejs.compile(source, merge(opts, {


### PR DESCRIPTION
Hello,

This fix #19

I tried to make it compatible with custom delimiters but I can't guaranty it.

It could serve as a base for a solution to EJS v3, as we could fetch the import content and replace it at build, instead of runtime.

Also, the tests seem broken.

Have a nice day